### PR TITLE
:bug: Handle `analyze: false` alonsgide with a custom format option

### DIFF
--- a/lib/activerecord-analyze.rb
+++ b/lib/activerecord-analyze.rb
@@ -91,5 +91,6 @@ module ActiveRecordAnalyze
       .gsub(/\(\s?\s?\s?,/, "(")
       .gsub(/\s,\s/, " ")
       .gsub(/\(\s?\)/, "")
+      .gsub(/,\s+\)/, ")")
   end
 end

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -50,6 +50,13 @@ describe "ActiveRecord analyze" do
     end
   end
 
+  describe "analyze:false with some format option" do
+    it "works" do
+      result = User.all.analyze(format: :pretty_json, analyze: false)
+      expect(JSON.parse(result)[0].keys.sort).to eq ["Plan"]
+    end
+  end
+
   describe "full_debug" do
     it "works" do
       result = User.all.analyze(full_debug: true)


### PR DESCRIPTION
If a format option was passed alongside `analyze: false` option it'd generate a wrong string due to a missing `gsub` to handle this case. That would generate a string such as `"(FORMAT JSON, )"` which is invalid SQL.

This fix adds a regex to detect and gsub this case and also a unit test to cover this up.

Closes #3